### PR TITLE
功能: 添加50级皎皎币支持（合并到Auto70jjbTask）

### DIFF
--- a/src/tasks/fullauto/Auto70jjbTask.py
+++ b/src/tasks/fullauto/Auto70jjbTask.py
@@ -311,12 +311,12 @@ class Auto70jjbTask(DNAOneTimeTask, CommissionsTask, BaseCombatTask):
         # 等待0.5秒后按下w
         self.sleep(0.5)
         self.send_key_down("w")
-        # 再等待1.0秒（总共1.5秒）后按下lshift
+        # 再等待1.0秒（总共1.5秒）后按下闪避键
         self.sleep(1.0)
-        self.send_key_down("lshift")
-        # 再等待5.5秒（总共7.0秒）后松开lshift
+        self.send_key_down(self.get_dodge_key())
+        # 再等待5.5秒（总共7.0秒）后松开闪避键
         self.sleep(5.5)
-        self.send_key_up("lshift")
+        self.send_key_up(self.get_dodge_key())
         # 再等待1.0秒（总共8.0秒）后松开w
         self.sleep(1.0)
         self.send_key_up("w")


### PR DESCRIPTION
如果单纯刷jjb，50jjb的效率比别的本高，而且打造武器很缺jjb，所以加入50jjb路线支持。

## 功能说明

为 `Auto70jjbTask` 添加50级皎皎币地图支持，现在可以同时支持50级和70级皎皎币副本。

## 实现逻辑

无需添加地图识别。当70jjb的四个地图都没有被识别到的时候，就执行50jjb的逻辑。50jjb的跑图逻辑也简单只是往前快走大约8秒。


## 修改文件
- `src/tasks/fullauto/Auto70jjbTask.py`