### PR TITLE
fix(CommissionsTask): 修复选择密函确认按钮点击/识别

### DIFF
--- a/src/tasks/CommissionsTask.py
+++ b/src/tasks/CommissionsTask.py
@@ -67,8 +67,8 @@ class CommissionsTask(BaseDNATask):
                                                                hcenter=True))
 
     def find_letter_btn(self, threshold=0):
-        return self.find_start_btn(
-            threshold=threshold, box=self.box_of_screen(0.6328, 0.6229, 0.7417, 0.6667, name="letter_btn",
+        return self.find_space_btn(
+            threshold=threshold, box=self.box_of_screen_scaled(3840, 2160, 2796, 1347, width_original=568 ,height_original=83, name="letter_btn",
                                                                hcenter=True))
 
     def find_letter_reward_btn(self, threshold=0):


### PR DESCRIPTION
## 概述
修复委托任务中“选择密函”流程里确认按钮识别，避免在进入密函选择后卡住。

## 主要变更
- 调整密函确认按钮的查找方式

## 影响范围
- 仅影响 CommissionsTask 中密函选择相关步骤


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 优化了UI元素检测机制，采用了改进的检测方法来定位界面组件，确保更准确的坐标识别和元素定位。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->