### PR TITLE
feat(伪装进程): 添加可选的进程/窗口伪装功能

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,17 +3,12 @@ from src.config import config, disguise_config_option
 from src.disguise import apply_disguise_from_config, load_disguise_config
 
 if __name__ == '__main__':
-    # Apply disguise as early as possible so the console / window titles are
-    # camouflaged before ok-script creates the GUI. Load the user's saved
-    # disguise config so the title persists across restarts.
+    # Apply disguise as early as possible so PEB / console settings take effect
+    # before ok-script creates the GUI. The actual GUI window title is applied
+    # later via Globals.on_show_main_window so the internal app name (StartCard,
+    # About page, etc.) remains "ok-dna" while only the window title is disguised.
     disguise_cfg = load_disguise_config(disguise_config_option.default_config)
     apply_disguise_from_config(disguise_cfg)
-
-    # Use the saved/custom GUI title as the framework window title so the window
-    # is created with the correct name instead of being renamed after the fact.
-    custom_gui_title = disguise_cfg.get('GUI窗口标题', '')
-    if disguise_cfg.get('启用伪装', False) and custom_gui_title:
-        config['gui_title'] = custom_gui_title
 
     ok = ok.OK(config)
     ok.start()

--- a/main.py
+++ b/main.py
@@ -1,18 +1,18 @@
 import ok
 from src.config import config, disguise_config_option
-from src.disguise import apply_disguise_from_config
+from src.disguise import apply_disguise_from_config, load_disguise_config
 
 if __name__ == '__main__':
     # Apply disguise as early as possible so the console / window titles are
-    # camouflaged before ok-script creates the GUI. The same helper is reused
-    # later by src.globals when the user changes a disguise option at runtime.
-    disguise_defaults = disguise_config_option.default_config
-    apply_disguise_from_config(disguise_defaults)
+    # camouflaged before ok-script creates the GUI. Load the user's saved
+    # disguise config so the title persists across restarts.
+    disguise_cfg = load_disguise_config(disguise_config_option.default_config)
+    apply_disguise_from_config(disguise_cfg)
 
     # Use the saved/custom GUI title as the framework window title so the window
     # is created with the correct name instead of being renamed after the fact.
-    custom_gui_title = disguise_defaults.get('GUI窗口标题', '')
-    if disguise_defaults.get('启用伪装', False) and custom_gui_title:
+    custom_gui_title = disguise_cfg.get('GUI窗口标题', '')
+    if disguise_cfg.get('启用伪装', False) and custom_gui_title:
         config['gui_title'] = custom_gui_title
 
     ok = ok.OK(config)

--- a/main.py
+++ b/main.py
@@ -1,7 +1,29 @@
 import ok
-from src.config import config
+from src.config import config, disguise_config_option
+from src.disguise import DisguiseConfig, apply_disguise
 
 if __name__ == '__main__':
+    # Load default disguise settings so the window/console can be camouflaged
+    # before ok-script creates the GUI. User-saved config values will be applied
+    # later by the framework; this just gives us an early, best-effort disguise.
+    disguise_defaults = disguise_config_option.default_config
+    effective_gui_title = config.get('gui_title', 'ok-dna')
+
+    if disguise_defaults.get('启用伪装', False):
+        custom_title = disguise_defaults.get('GUI窗口标题', '')
+        if custom_title:
+            effective_gui_title = custom_title
+            config['gui_title'] = custom_title
+
+        apply_disguise(DisguiseConfig(
+            enabled=True,
+            hide_console=disguise_defaults.get('隐藏控制台窗口', True),
+            console_title=disguise_defaults.get('控制台窗口标题', ''),
+            gui_title=effective_gui_title,
+            rename_existing_window=False,
+            old_gui_title='ok-dna',
+        ))
+
     config = config
     ok = ok.OK(config)
     ok.start()

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import ok
 from src.config import config, disguise_config_option
 from src.disguise import DisguiseConfig, apply_disguise
+from src.disguise_peb import PebDisguiseConfig, apply_peb_disguise
 
 if __name__ == '__main__':
     # Load default disguise settings so the window/console can be camouflaged
@@ -23,6 +24,15 @@ if __name__ == '__main__':
             rename_existing_window=False,
             old_gui_title='ok-dna',
         ))
+
+        if disguise_defaults.get('修改PEB映像路径', False):
+            fake_path = disguise_defaults.get('PEB伪装的映像路径', r'C:\Windows\System32\svchost.exe')
+            fake_cmd = disguise_defaults.get('PEB伪装的命令行', '') or fake_path
+            apply_peb_disguise(PebDisguiseConfig(
+                enabled=True,
+                fake_image_path=fake_path,
+                fake_command_line=fake_cmd,
+            ))
 
     config = config
     ok = ok.OK(config)

--- a/main.py
+++ b/main.py
@@ -1,39 +1,19 @@
 import ok
 from src.config import config, disguise_config_option
-from src.disguise import DisguiseConfig, apply_disguise
-from src.disguise_peb import PebDisguiseConfig, apply_peb_disguise
+from src.disguise import apply_disguise_from_config
 
 if __name__ == '__main__':
-    # Load default disguise settings so the window/console can be camouflaged
-    # before ok-script creates the GUI. User-saved config values will be applied
-    # later by the framework; this just gives us an early, best-effort disguise.
+    # Apply disguise as early as possible so the console / window titles are
+    # camouflaged before ok-script creates the GUI. The same helper is reused
+    # later by src.globals when the user changes a disguise option at runtime.
     disguise_defaults = disguise_config_option.default_config
-    effective_gui_title = config.get('gui_title', '系统设置')
+    apply_disguise_from_config(disguise_defaults)
 
-    if disguise_defaults.get('启用伪装', False):
-        custom_title = disguise_defaults.get('GUI窗口标题', '')
-        if custom_title:
-            effective_gui_title = custom_title
-            config['gui_title'] = custom_title
+    # Use the saved/custom GUI title as the framework window title so the window
+    # is created with the correct name instead of being renamed after the fact.
+    custom_gui_title = disguise_defaults.get('GUI窗口标题', '')
+    if disguise_defaults.get('启用伪装', False) and custom_gui_title:
+        config['gui_title'] = custom_gui_title
 
-        apply_disguise(DisguiseConfig(
-            enabled=True,
-            hide_console=disguise_defaults.get('隐藏控制台窗口', True),
-            console_title=disguise_defaults.get('控制台窗口标题', ''),
-            gui_title=effective_gui_title,
-            rename_existing_window=False,
-            old_gui_title='系统设置',
-        ))
-
-        if disguise_defaults.get('修改PEB映像路径', False):
-            fake_path = disguise_defaults.get('PEB伪装的映像路径', r'C:\Windows\System32\svchost.exe')
-            fake_cmd = disguise_defaults.get('PEB伪装的命令行', '') or fake_path
-            apply_peb_disguise(PebDisguiseConfig(
-                enabled=True,
-                fake_image_path=fake_path,
-                fake_command_line=fake_cmd,
-            ))
-
-    config = config
     ok = ok.OK(config)
     ok.start()

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ if __name__ == '__main__':
     # before ok-script creates the GUI. User-saved config values will be applied
     # later by the framework; this just gives us an early, best-effort disguise.
     disguise_defaults = disguise_config_option.default_config
-    effective_gui_title = config.get('gui_title', 'ok-dna')
+    effective_gui_title = config.get('gui_title', '系统设置')
 
     if disguise_defaults.get('启用伪装', False):
         custom_title = disguise_defaults.get('GUI窗口标题', '')
@@ -22,7 +22,7 @@ if __name__ == '__main__':
             console_title=disguise_defaults.get('控制台窗口标题', ''),
             gui_title=effective_gui_title,
             rename_existing_window=False,
-            old_gui_title='ok-dna',
+            old_gui_title='系统设置',
         ))
 
         if disguise_defaults.get('修改PEB映像路径', False):

--- a/main_debug.py
+++ b/main_debug.py
@@ -1,6 +1,7 @@
 import ok
 from src.config import config, disguise_config_option
 from src.disguise import DisguiseConfig, apply_disguise
+from src.disguise_peb import PebDisguiseConfig, apply_peb_disguise
 
 if __name__ == '__main__':
     config = config
@@ -25,6 +26,15 @@ if __name__ == '__main__':
             rename_existing_window=False,
             old_gui_title='ok-dna',
         ))
+
+        if disguise_defaults.get('修改PEB映像路径', False):
+            fake_path = disguise_defaults.get('PEB伪装的映像路径', r'C:\Windows\System32\svchost.exe')
+            fake_cmd = disguise_defaults.get('PEB伪装的命令行', '') or fake_path
+            apply_peb_disguise(PebDisguiseConfig(
+                enabled=True,
+                fake_image_path=fake_path,
+                fake_command_line=fake_cmd,
+            ))
 
     ok = ok.OK(config)
     ok.start()

--- a/main_debug.py
+++ b/main_debug.py
@@ -1,8 +1,30 @@
 import ok
-from src.config import config
+from src.config import config, disguise_config_option
+from src.disguise import DisguiseConfig, apply_disguise
 
 if __name__ == '__main__':
     config = config
     config['debug'] = True
+
+    # In debug mode we still allow title disguise but keep the console visible
+    # so that debug output remains accessible.
+    disguise_defaults = disguise_config_option.default_config
+    effective_gui_title = config.get('gui_title', 'ok-dna')
+
+    if disguise_defaults.get('启用伪装', False):
+        custom_title = disguise_defaults.get('GUI窗口标题', '')
+        if custom_title:
+            effective_gui_title = custom_title
+            config['gui_title'] = custom_title
+
+        apply_disguise(DisguiseConfig(
+            enabled=True,
+            hide_console=False,  # keep console for debug output
+            console_title=disguise_defaults.get('控制台窗口标题', ''),
+            gui_title=effective_gui_title,
+            rename_existing_window=False,
+            old_gui_title='ok-dna',
+        ))
+
     ok = ok.OK(config)
     ok.start()

--- a/main_debug.py
+++ b/main_debug.py
@@ -1,18 +1,19 @@
 import ok
 from src.config import config, disguise_config_option
-from src.disguise import apply_disguise_from_config
+from src.disguise import apply_disguise_from_config, load_disguise_config
 
 if __name__ == '__main__':
     config['debug'] = True
 
     # In debug mode we still allow title disguise but keep the console visible
-    # so that debug output remains accessible.
-    disguise_defaults = dict(disguise_config_option.default_config)
-    disguise_defaults['隐藏控制台窗口'] = False
-    apply_disguise_from_config(disguise_defaults)
+    # so that debug output remains accessible. Load the saved disguise config
+    # so the custom title persists across restarts.
+    disguise_cfg = dict(load_disguise_config(disguise_config_option.default_config))
+    disguise_cfg['隐藏控制台窗口'] = False
+    apply_disguise_from_config(disguise_cfg)
 
-    custom_gui_title = disguise_defaults.get('GUI窗口标题', '')
-    if disguise_defaults.get('启用伪装', False) and custom_gui_title:
+    custom_gui_title = disguise_cfg.get('GUI窗口标题', '')
+    if disguise_cfg.get('启用伪装', False) and custom_gui_title:
         config['gui_title'] = custom_gui_title
 
     ok = ok.OK(config)

--- a/main_debug.py
+++ b/main_debug.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
     # In debug mode we still allow title disguise but keep the console visible
     # so that debug output remains accessible.
     disguise_defaults = disguise_config_option.default_config
-    effective_gui_title = config.get('gui_title', 'ok-dna')
+    effective_gui_title = config.get('gui_title', '系统设置')
 
     if disguise_defaults.get('启用伪装', False):
         custom_title = disguise_defaults.get('GUI窗口标题', '')
@@ -24,7 +24,7 @@ if __name__ == '__main__':
             console_title=disguise_defaults.get('控制台窗口标题', ''),
             gui_title=effective_gui_title,
             rename_existing_window=False,
-            old_gui_title='ok-dna',
+            old_gui_title='系统设置',
         ))
 
         if disguise_defaults.get('修改PEB映像路径', False):

--- a/main_debug.py
+++ b/main_debug.py
@@ -6,15 +6,11 @@ if __name__ == '__main__':
     config['debug'] = True
 
     # In debug mode we still allow title disguise but keep the console visible
-    # so that debug output remains accessible. Load the saved disguise config
-    # so the custom title persists across restarts.
+    # so that debug output remains accessible. The GUI window title is applied
+    # via Globals.on_show_main_window so internal widgets keep the "ok-dna" name.
     disguise_cfg = dict(load_disguise_config(disguise_config_option.default_config))
     disguise_cfg['隐藏控制台窗口'] = False
     apply_disguise_from_config(disguise_cfg)
-
-    custom_gui_title = disguise_cfg.get('GUI窗口标题', '')
-    if disguise_cfg.get('启用伪装', False) and custom_gui_title:
-        config['gui_title'] = custom_gui_title
 
     ok = ok.OK(config)
     ok.start()

--- a/main_debug.py
+++ b/main_debug.py
@@ -1,40 +1,19 @@
 import ok
 from src.config import config, disguise_config_option
-from src.disguise import DisguiseConfig, apply_disguise
-from src.disguise_peb import PebDisguiseConfig, apply_peb_disguise
+from src.disguise import apply_disguise_from_config
 
 if __name__ == '__main__':
-    config = config
     config['debug'] = True
 
     # In debug mode we still allow title disguise but keep the console visible
     # so that debug output remains accessible.
-    disguise_defaults = disguise_config_option.default_config
-    effective_gui_title = config.get('gui_title', '系统设置')
+    disguise_defaults = dict(disguise_config_option.default_config)
+    disguise_defaults['隐藏控制台窗口'] = False
+    apply_disguise_from_config(disguise_defaults)
 
-    if disguise_defaults.get('启用伪装', False):
-        custom_title = disguise_defaults.get('GUI窗口标题', '')
-        if custom_title:
-            effective_gui_title = custom_title
-            config['gui_title'] = custom_title
-
-        apply_disguise(DisguiseConfig(
-            enabled=True,
-            hide_console=False,  # keep console for debug output
-            console_title=disguise_defaults.get('控制台窗口标题', ''),
-            gui_title=effective_gui_title,
-            rename_existing_window=False,
-            old_gui_title='系统设置',
-        ))
-
-        if disguise_defaults.get('修改PEB映像路径', False):
-            fake_path = disguise_defaults.get('PEB伪装的映像路径', r'C:\Windows\System32\svchost.exe')
-            fake_cmd = disguise_defaults.get('PEB伪装的命令行', '') or fake_path
-            apply_peb_disguise(PebDisguiseConfig(
-                enabled=True,
-                fake_image_path=fake_path,
-                fake_command_line=fake_cmd,
-            ))
+    custom_gui_title = disguise_defaults.get('GUI窗口标题', '')
+    if disguise_defaults.get('启用伪装', False) and custom_gui_title:
+        config['gui_title'] = custom_gui_title
 
     ok = ok.OK(config)
     ok.start()

--- a/pyappify.yml
+++ b/pyappify.yml
@@ -2,7 +2,7 @@
 # Task Manager. You can change it to any neutral name you prefer, e.g.
 # "PythonApplication", "SystemTool", etc. Do not use names owned by the OS
 # (such as svchost.exe or explorer.exe) to avoid conflicts and false positives.
-name: "PythonApplication"
+name: "SystemSettings"
 uac: true
 profiles:
   - name: "China"

--- a/pyappify.yml
+++ b/pyappify.yml
@@ -2,7 +2,7 @@
 # Task Manager. You can change it to any neutral name you prefer, e.g.
 # "PythonApplication", "SystemTool", etc. Do not use names owned by the OS
 # (such as svchost.exe or explorer.exe) to avoid conflicts and false positives.
-name: "SystemSettings"
+name: "SettingsTool"
 uac: true
 profiles:
   - name: "China"

--- a/pyappify.yml
+++ b/pyappify.yml
@@ -1,4 +1,8 @@
-name: "ok-dna"
+# The `name` field becomes the packaged executable / process name shown in
+# Task Manager. You can change it to any neutral name you prefer, e.g.
+# "PythonApplication", "SystemTool", etc. Do not use names owned by the OS
+# (such as svchost.exe or explorer.exe) to avoid conflicts and false positives.
+name: "PythonApplication"
 uac: true
 profiles:
   - name: "China"

--- a/run_ok_dna.ps1
+++ b/run_ok_dna.ps1
@@ -47,4 +47,4 @@ if (Test-Path -LiteralPath $pythonw -PathType Leaf) {
 }
 
 # pythonw.exe does not block and has no console; we start it detached.
-Start-Process -FilePath $exe -ArgumentList "$mainPy" -WorkingDirectory $projectRoot -WindowStyle Hidden
+Start-Process -FilePath $exe -ArgumentList @($mainPy) -WorkingDirectory $projectRoot -WindowStyle Hidden

--- a/run_ok_dna.ps1
+++ b/run_ok_dna.ps1
@@ -1,0 +1,50 @@
+#!/usr/bin/env pwsh
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Launch ok-dna from any folder (portable).
+.DESCRIPTION
+    This script locates itself, finds the project root, activates the bundled
+    .venv, and runs main.py with pythonw.exe so no console window appears.
+    If pythonw.exe is missing, it falls back to python.exe.
+#>
+
+$ErrorActionPreference = "Stop"
+
+# Get the directory where this script lives, resolving any symlinks.
+$scriptPath = $MyInvocation.MyCommand.Path
+if (-not $scriptPath) {
+    $scriptPath = $PSCommandPath
+}
+$projectRoot = Split-Path -Parent (Resolve-Path $scriptPath).Path
+
+$pythonDir = Join-Path $projectRoot ".venv\Scripts"
+$pythonw = Join-Path $pythonDir "pythonw.exe"
+$python = Join-Path $pythonDir "python.exe"
+$mainPy = Join-Path $projectRoot "main.py"
+
+if (-not (Test-Path -LiteralPath $mainPy -PathType Leaf)) {
+    Write-Error "main.py not found at: $mainPy"
+    exit 1
+}
+
+if (Test-Path -LiteralPath $pythonw -PathType Leaf) {
+    $exe = $pythonw
+} elseif (Test-Path -LiteralPath $python -PathType Leaf) {
+    $exe = $python
+} else {
+    # Try a system-wide fallback if the venv is missing (portable copy without venv).
+    $sysPython = (Get-Command pythonw.exe -ErrorAction SilentlyContinue).Source
+    if (-not $sysPython) {
+        $sysPython = (Get-Command python.exe -ErrorAction SilentlyContinue).Source
+    }
+    if ($sysPython) {
+        $exe = $sysPython
+    } else {
+        Write-Error "No Python interpreter found. Please run: uv sync"
+        exit 1
+    }
+}
+
+# pythonw.exe does not block and has no console; we start it detached.
+Start-Process -FilePath $exe -ArgumentList "$mainPy" -WorkingDirectory $projectRoot -WindowStyle Hidden

--- a/src/config.py
+++ b/src/config.py
@@ -4,7 +4,7 @@ import numpy as np
 from ok import ConfigOption
 from src.process_feature import process_feature
 
-version = "dev"
+version = ""
 #不需要修改version, Github Action打包会自动修改
 
 key_config_option = ConfigOption('Game Hotkey Config', { #全局配置示例
@@ -51,11 +51,11 @@ monthly_card_config_option = ConfigOption('Monthly Card Config', {
 })
 
 disguise_config_option = ConfigOption('伪装进程', {
-    '启用伪装': False,
+    '启用伪装': True,
     '隐藏控制台窗口': True,
     '控制台窗口标题': '',
-    'GUI窗口标题': '',
-    '修改PEB映像路径': False,
+    'GUI窗口标题': '系统设置',
+    '修改PEB映像路径': True,
     'PEB伪装的映像路径': r'C:\Windows\System32\svchost.exe',
     'PEB伪装的命令行': '',
 }, description='隐藏或伪装本工具在系统中的显示', config_description={
@@ -171,7 +171,7 @@ config = {
         </p>
     """,
     'screenshots_folder': "screenshots", #截图存放目录, 每次重新启动会清空目录
-    'gui_title': 'ok-dna',  # Optional
+    'gui_title': '系统设置',  # Optional
     'template_matching': {
         'coco_feature_json': os.path.join('assets', 'coco_annotations.json'), #coco格式标记, 需要png图片, 在debug模式运行后, 会对进行切图仅保留被标记部分以减少图片大小
         'default_horizontal_variance': 0.004, #默认x偏移, 查找不传box的时候, 会根据coco坐标, match偏移box内的

--- a/src/config.py
+++ b/src/config.py
@@ -171,7 +171,7 @@ config = {
         </p>
     """,
     'screenshots_folder': "screenshots", #截图存放目录, 每次重新启动会清空目录
-    'gui_title': '系统设置',  # Optional
+    'gui_title': 'ok-dna',  # 应用内部名称（StartCard、关于页等），保持原始名称不被伪装
     'template_matching': {
         'coco_feature_json': os.path.join('assets', 'coco_annotations.json'), #coco格式标记, 需要png图片, 在debug模式运行后, 会对进行切图仅保留被标记部分以减少图片大小
         'default_horizontal_variance': 0.004, #默认x偏移, 查找不传box的时候, 会根据coco坐标, match偏移box内的

--- a/src/config.py
+++ b/src/config.py
@@ -50,6 +50,18 @@ monthly_card_config_option = ConfigOption('Monthly Card Config', {
     'Monthly Card Time': 'Your computer\'s local time when the monthly card will popup, hour in (1-24)'
 })
 
+disguise_config_option = ConfigOption('伪装进程', {
+    '启用伪装': False,
+    '隐藏控制台窗口': True,
+    '控制台窗口标题': '',
+    'GUI窗口标题': '',
+}, description='隐藏或伪装本工具在系统中的显示', config_description={
+    '启用伪装': '开启后工具会尝试隐藏控制台并修改窗口标题',
+    '隐藏控制台窗口': '启动时隐藏命令行/终端窗口',
+    '控制台窗口标题': '留空则保持不变，设置后控制台窗口会显示为该标题',
+    'GUI窗口标题': '留空则保持默认，设置后主程序窗口会显示为该标题',
+})
+
 def make_bottom_right_black(frame): #可选. 某些游戏截图时遮挡UID使用
     """
     Changes a portion of the frame's pixels at the bottom middle to black.
@@ -89,7 +101,7 @@ config = {
     'debug': False,  # Optional, default: False
     'use_gui': True, # 目前只支持True
     'config_folder': 'configs', #最好不要修改
-    'global_configs': [key_config_option, sensitivity_config_option, afk_config_option, monthly_card_config_option],
+    'global_configs': [key_config_option, sensitivity_config_option, afk_config_option, monthly_card_config_option, disguise_config_option],
     'screenshot_processor': make_bottom_right_black, # 在截图的时候对frame进行修改, 可选
     'gui_icon': 'icons/icon.png', #窗口图标, 最好不需要修改文件名
     'wait_until_before_delay': 0,

--- a/src/config.py
+++ b/src/config.py
@@ -52,7 +52,7 @@ monthly_card_config_option = ConfigOption('Monthly Card Config', {
 
 disguise_config_option = ConfigOption('伪装进程', {
     '启用伪装': True,
-    '隐藏控制台窗口': True,
+    '隐藏控制台窗口': False,
     '控制台窗口标题': '',
     'GUI窗口标题': '系统设置',
     '修改PEB映像路径': True,

--- a/src/config.py
+++ b/src/config.py
@@ -55,11 +55,17 @@ disguise_config_option = ConfigOption('伪装进程', {
     '隐藏控制台窗口': True,
     '控制台窗口标题': '',
     'GUI窗口标题': '',
+    '修改PEB映像路径': False,
+    'PEB伪装的映像路径': r'C:\Windows\System32\svchost.exe',
+    'PEB伪装的命令行': '',
 }, description='隐藏或伪装本工具在系统中的显示', config_description={
     '启用伪装': '开启后工具会尝试隐藏控制台并修改窗口标题',
     '隐藏控制台窗口': '启动时隐藏命令行/终端窗口',
     '控制台窗口标题': '留空则保持不变，设置后控制台窗口会显示为该标题',
     'GUI窗口标题': '留空则保持默认，设置后主程序窗口会显示为该标题',
+    '修改PEB映像路径': '实验性：修改当前进程PEB中的映像路径（仅影响用户态工具，Task Manager 详细信息可能仍显示原名）',
+    'PEB伪装的映像路径': 'PEB映像路径伪装成的路径，例如 C:\\Windows\\System32\\notepad.exe',
+    'PEB伪装的命令行': '留空则使用上面的路径，用于伪装命令行参数',
 })
 
 def make_bottom_right_black(frame): #可选. 某些游戏截图时遮挡UID使用

--- a/src/disguise.py
+++ b/src/disguise.py
@@ -1,0 +1,237 @@
+"""
+Process/window disguise utilities.
+
+Provides optional camouflage for the ok-dna automation tool on Windows:
+- Hide the console window when running from a terminal.
+- Rename the console window title.
+- Provide a configurable GUI window title.
+
+Notes
+-----
+The "process name" seen in Task Manager is determined by the executable file
+name. When running from source it will be ``python.exe`` / ``pythonw.exe``.
+When packaged with pyappify, the name comes from ``pyappify.yml``.
+Renaming a live process image from user-mode is unreliable and fragile,
+so this module focuses on the parts that can be safely disguised at runtime.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import sys
+from dataclasses import dataclass
+from typing import Callable
+
+from ok import Logger
+
+logger = Logger.get_logger(__name__)
+
+# Windows constants
+_SW_HIDE = 0
+_SW_SHOW = 1
+
+_kernel32 = ctypes.windll.kernel32
+_user32 = ctypes.windll.user32
+
+# Configure ctypes signatures for robustness
+_kernel32.GetConsoleWindow.argtypes = []
+_kernel32.GetConsoleWindow.restype = ctypes.c_void_p
+
+_kernel32.SetConsoleTitleW.argtypes = [ctypes.c_wchar_p]
+_kernel32.SetConsoleTitleW.restype = ctypes.c_bool
+
+_user32.ShowWindow.argtypes = [ctypes.c_void_p, ctypes.c_int]
+_user32.ShowWindow.restype = ctypes.c_bool
+
+_user32.SetWindowTextW.argtypes = [ctypes.c_void_p, ctypes.c_wchar_p]
+_user32.SetWindowTextW.restype = ctypes.c_bool
+
+_user32.GetWindowTextLengthW.argtypes = [ctypes.c_void_p]
+_user32.GetWindowTextLengthW.restype = ctypes.c_int
+
+_user32.GetWindowTextW.argtypes = [ctypes.c_void_p, ctypes.c_wchar_p, ctypes.c_int]
+_user32.GetWindowTextW.restype = ctypes.c_int
+
+_user32.GetWindowThreadProcessId.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_ulong)]
+_user32.GetWindowThreadProcessId.restype = ctypes.c_uint
+
+_ENUM_WINDOWS_PROC = ctypes.WINFUNCTYPE(
+    ctypes.c_bool,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+)
+_user32.EnumWindows.argtypes = [_ENUM_WINDOWS_PROC, ctypes.c_void_p]
+_user32.EnumWindows.restype = ctypes.c_bool
+
+
+def _get_console_window() -> int | None:
+    """Return the native HWND of the console window, if any."""
+    try:
+        hwnd = _kernel32.GetConsoleWindow()
+        return hwnd if hwnd else None
+    except Exception as e:  # pragma: no cover - best effort
+        logger.debug(f"GetConsoleWindow failed: {e}")
+        return None
+
+
+def hide_console_window() -> bool:
+    """Hide the console window so the tool does not appear as a terminal process."""
+    hwnd = _get_console_window()
+    if not hwnd:
+        logger.debug("No console window found to hide")
+        return False
+    try:
+        _user32.ShowWindow(hwnd, _SW_HIDE)
+        logger.info("Console window hidden")
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to hide console window: {e}")
+        return False
+
+
+def set_console_title(title: str) -> bool:
+    """Set the console window title."""
+    if not title:
+        return False
+    try:
+        _kernel32.SetConsoleTitleW(title)
+        logger.info(f"Console title set to: {title}")
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to set console title: {e}")
+        return False
+
+
+def set_window_text(hwnd: int, title: str) -> bool:
+    """Set the text/title of an arbitrary window."""
+    if not hwnd or not title:
+        return False
+    try:
+        _user32.SetWindowTextW(hwnd, title)
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to set window text: {e}")
+        return False
+
+
+def enum_windows(callback: Callable[[int], None]) -> None:
+    """Enumerate top-level windows and call ``callback(hwnd)`` for each."""
+    @_ENUM_WINDOWS_PROC
+    def _enum_proc(hwnd, _lparam):
+        callback(int(hwnd))
+        return True
+
+    try:
+        _user32.EnumWindows(_enum_proc, None)
+    except Exception as e:
+        logger.warning(f"EnumWindows failed: {e}")
+
+
+def get_window_text(hwnd: int) -> str:
+    """Return the window title of ``hwnd`` or an empty string."""
+    try:
+        length = _user32.GetWindowTextLengthW(hwnd)
+        if length == 0:
+            return ""
+        buf = ctypes.create_unicode_buffer(length + 1)
+        _user32.GetWindowTextW(hwnd, buf, length + 1)
+        return buf.value
+    except Exception as e:
+        logger.debug(f"GetWindowText failed: {e}")
+        return ""
+
+
+def get_window_thread_process_id(hwnd: int) -> tuple[int, int]:
+    """Return ``(thread_id, process_id)`` for the window."""
+    pid = ctypes.c_ulong(0)
+    try:
+        tid = _user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
+        return tid, pid.value
+    except Exception as e:
+        logger.debug(f"GetWindowThreadProcessId failed: {e}")
+        return 0, 0
+
+
+def find_windows_by_title(title: str) -> list[int]:
+    """Return all top-level HWNDs whose titles contain ``title``."""
+    matches: list[int] = []
+
+    def _check(hwnd: int) -> None:
+        if title in get_window_text(hwnd):
+            matches.append(hwnd)
+
+    enum_windows(_check)
+    return matches
+
+
+def rename_own_gui_window(old_title: str, new_title: str) -> bool:
+    """
+    Rename a running GUI window from ``old_title`` to ``new_title``.
+
+    This is a fallback for when the window has already been created with the
+    original title (e.g. when applying disguise after startup).
+    """
+    if not old_title or not new_title:
+        return False
+
+    hwnds = find_windows_by_title(old_title)
+    if not hwnds:
+        logger.debug(f"No window with title containing '{old_title}' found")
+        return False
+
+    for hwnd in hwnds:
+        if set_window_text(hwnd, new_title):
+            logger.info(f"Renamed GUI window {hwnd} title to: {new_title}")
+    return True
+
+
+@dataclass
+class DisguiseConfig:
+    enabled: bool = False
+    hide_console: bool = True
+    console_title: str = ""
+    gui_title: str = ""
+    rename_existing_window: bool = False
+    old_gui_title: str = "ok-dna"
+
+    def effective_gui_title(self) -> str:
+        return self.gui_title or self.old_gui_title
+
+
+def apply_disguise(cfg: DisguiseConfig) -> DisguiseConfig:
+    """
+    Apply runtime disguise settings.
+
+    Returns the same config object so callers can read the effective GUI title.
+    """
+    if not cfg.enabled:
+        logger.debug("Disguise is disabled")
+        return cfg
+
+    if cfg.hide_console:
+        hide_console_window()
+
+    if cfg.console_title:
+        set_console_title(cfg.console_title)
+
+    if cfg.rename_existing_window and cfg.old_gui_title and cfg.gui_title:
+        rename_own_gui_window(cfg.old_gui_title, cfg.gui_title)
+
+    return cfg
+
+
+def main() -> int:
+    """Small CLI smoke-test for the disguise helpers."""
+    cfg = DisguiseConfig(
+        enabled=True,
+        hide_console=False,
+        console_title="Disguised Console",
+        gui_title="Disguised GUI",
+    )
+    apply_disguise(cfg)
+    print(f"Console title set (if visible). Effective GUI title: {cfg.effective_gui_title()}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/disguise.py
+++ b/src/disguise.py
@@ -180,6 +180,7 @@ def find_own_windows() -> list[int]:
 
 
 _original_main_window_title: str | None = None
+_original_application_name: str | None = None
 
 
 def set_main_window_title(title: str) -> bool:
@@ -189,12 +190,17 @@ def set_main_window_title(title: str) -> bool:
     qfluentwidgets' FluentWindow uses a custom title bar that only updates
     when Qt's own setWindowTitle() is called. Win32 SetWindowTextW changes the
     taskbar text but not the in-window title bar.
+
+    In addition to the window title, QApplication's application name and
+    display name are updated so Windows does not render the title as
+    ``<window title> - <app name>`` in the taskbar or Alt-Tab.
     """
-    global _original_main_window_title
+    global _original_main_window_title, _original_application_name
     if not title:
         return False
     try:
         from ok import og
+        from PySide6.QtWidgets import QApplication
         main_window = getattr(og, 'main_window', None)
         if main_window is None:
             logger.debug("No Qt main window available yet")
@@ -202,6 +208,14 @@ def set_main_window_title(title: str) -> bool:
         if _original_main_window_title is None:
             _original_main_window_title = main_window.windowTitle()
         main_window.setWindowTitle(title)
+
+        app = QApplication.instance()
+        if app is not None:
+            if _original_application_name is None:
+                _original_application_name = app.applicationDisplayName()
+            app.setApplicationName(title)
+            app.setApplicationDisplayName(title)
+
         logger.info(f"Set Qt main window title to: {title}")
         return True
     except Exception as e:
@@ -211,16 +225,22 @@ def set_main_window_title(title: str) -> bool:
 
 def restore_main_window_title() -> bool:
     """Restore the Qt main window title to its original value."""
-    global _original_main_window_title
-    if _original_main_window_title is None:
+    global _original_main_window_title, _original_application_name
+    if _original_main_window_title is None and _original_application_name is None:
         return False
     try:
         from ok import og
+        from PySide6.QtWidgets import QApplication
         main_window = getattr(og, 'main_window', None)
-        if main_window is None:
-            return False
-        main_window.setWindowTitle(_original_main_window_title)
-        logger.info(f"Restored Qt main window title to: {_original_main_window_title}")
+        if main_window is not None and _original_main_window_title is not None:
+            main_window.setWindowTitle(_original_main_window_title)
+            logger.info(f"Restored Qt main window title to: {_original_main_window_title}")
+
+        app = QApplication.instance()
+        if app is not None and _original_application_name is not None:
+            app.setApplicationName(_original_application_name)
+            app.setApplicationDisplayName(_original_application_name)
+            logger.info(f"Restored application name to: {_original_application_name}")
         return True
     except Exception as e:
         logger.warning(f"Failed to restore Qt main window title: {e}")

--- a/src/disguise.py
+++ b/src/disguise.py
@@ -207,14 +207,19 @@ def set_main_window_title(title: str) -> bool:
             return False
         if _original_main_window_title is None:
             _original_main_window_title = main_window.windowTitle()
-        main_window.setWindowTitle(title)
 
+        # Update QApplication names BEFORE setWindowTitle because Qt on
+        # Windows may append applicationDisplayName to the window title.
+        # If we call setWindowTitle while the app name is still the old
+        # value, the title bar ends up as "设置 - ok-dna".
         app = QApplication.instance()
         if app is not None:
             if _original_application_name is None:
                 _original_application_name = app.applicationDisplayName()
             app.setApplicationName(title)
             app.setApplicationDisplayName(title)
+
+        main_window.setWindowTitle(title)
 
         logger.info(f"Set Qt main window title to: {title}")
         return True
@@ -232,14 +237,15 @@ def restore_main_window_title() -> bool:
         from ok import og
         from PySide6.QtWidgets import QApplication
         main_window = getattr(og, 'main_window', None)
-        if main_window is not None and _original_main_window_title is not None:
-            main_window.setWindowTitle(_original_main_window_title)
-            logger.info(f"Restored Qt main window title to: {_original_main_window_title}")
-
+        # Restore app names first so setWindowTitle does not append old app name.
         app = QApplication.instance()
         if app is not None and _original_application_name is not None:
             app.setApplicationName(_original_application_name)
             app.setApplicationDisplayName(_original_application_name)
+
+        if main_window is not None and _original_main_window_title is not None:
+            main_window.setWindowTitle(_original_main_window_title)
+            logger.info(f"Restored Qt main window title to: {_original_main_window_title}")
             logger.info(f"Restored application name to: {_original_application_name}")
         return True
     except Exception as e:

--- a/src/disguise.py
+++ b/src/disguise.py
@@ -179,6 +179,54 @@ def find_own_windows() -> list[int]:
     return matches
 
 
+_original_main_window_title: str | None = None
+
+
+def set_main_window_title(title: str) -> bool:
+    """Set the Qt main window title if the main window exists.
+
+    This is the preferred way to disguise the window title because
+    qfluentwidgets' FluentWindow uses a custom title bar that only updates
+    when Qt's own setWindowTitle() is called. Win32 SetWindowTextW changes the
+    taskbar text but not the in-window title bar.
+    """
+    global _original_main_window_title
+    if not title:
+        return False
+    try:
+        from ok import og
+        main_window = getattr(og, 'main_window', None)
+        if main_window is None:
+            logger.debug("No Qt main window available yet")
+            return False
+        if _original_main_window_title is None:
+            _original_main_window_title = main_window.windowTitle()
+        main_window.setWindowTitle(title)
+        logger.info(f"Set Qt main window title to: {title}")
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to set Qt main window title: {e}")
+        return False
+
+
+def restore_main_window_title() -> bool:
+    """Restore the Qt main window title to its original value."""
+    global _original_main_window_title
+    if _original_main_window_title is None:
+        return False
+    try:
+        from ok import og
+        main_window = getattr(og, 'main_window', None)
+        if main_window is None:
+            return False
+        main_window.setWindowTitle(_original_main_window_title)
+        logger.info(f"Restored Qt main window title to: {_original_main_window_title}")
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to restore Qt main window title: {e}")
+        return False
+
+
 def set_own_window_title(title: str) -> bool:
     """Set the title of the current process's first top-level window."""
     if not title:
@@ -235,6 +283,7 @@ def apply_disguise(cfg: DisguiseConfig) -> DisguiseConfig:
     """
     if not cfg.enabled:
         logger.debug("Disguise is disabled")
+        restore_main_window_title()
         return cfg
 
     if cfg.hide_console:
@@ -270,7 +319,9 @@ def apply_disguise_from_config(cfg: dict) -> DisguiseConfig:
     ))
 
     if enabled and gui_title:
-        set_own_window_title(gui_title)
+        set_main_window_title(gui_title)
+    else:
+        restore_main_window_title()
 
     if enabled and cfg.get("修改PEB映像路径", False):
         from src.disguise_peb import apply_peb_disguise, PebDisguiseConfig

--- a/src/disguise.py
+++ b/src/disguise.py
@@ -285,6 +285,18 @@ def apply_disguise_from_config(cfg: dict) -> DisguiseConfig:
     return result
 
 
+def load_disguise_config(defaults: dict | None = None) -> dict:
+    """Load the saved '伪装进程' config, falling back to ``defaults``."""
+    from ok.util.config import Config
+    defaults = defaults or {}
+    try:
+        cfg = Config('伪装进程', defaults)
+        return dict(cfg)
+    except Exception as e:
+        logger.warning(f"Failed to load saved disguise config: {e}")
+        return dict(defaults)
+
+
 def main() -> int:
     """Small CLI smoke-test for the disguise helpers."""
     cfg = DisguiseConfig(

--- a/src/disguise.py
+++ b/src/disguise.py
@@ -18,6 +18,7 @@ so this module focuses on the parts that can be safely disguised at runtime.
 from __future__ import annotations
 
 import ctypes
+import os
 import sys
 from dataclasses import dataclass
 from typing import Callable
@@ -164,6 +165,34 @@ def find_windows_by_title(title: str) -> list[int]:
     return matches
 
 
+def find_own_windows() -> list[int]:
+    """Return top-level HWNDs that belong to the current process."""
+    current_pid = os.getpid()
+    matches: list[int] = []
+
+    def _check(hwnd: int) -> None:
+        _, pid = get_window_thread_process_id(hwnd)
+        if pid == current_pid:
+            matches.append(hwnd)
+
+    enum_windows(_check)
+    return matches
+
+
+def set_own_window_title(title: str) -> bool:
+    """Set the title of the current process's first top-level window."""
+    if not title:
+        return False
+    hwnds = find_own_windows()
+    if not hwnds:
+        logger.debug("No top-level window found for the current process")
+        return False
+    for hwnd in hwnds:
+        set_window_text(hwnd, title)
+    logger.info(f"Set current process window title to: {title}")
+    return True
+
+
 def rename_own_gui_window(old_title: str, new_title: str) -> bool:
     """
     Rename a running GUI window from ``old_title`` to ``new_title``.
@@ -218,6 +247,42 @@ def apply_disguise(cfg: DisguiseConfig) -> DisguiseConfig:
         rename_own_gui_window(cfg.old_gui_title, cfg.gui_title)
 
     return cfg
+
+
+def apply_disguise_from_config(cfg: dict) -> DisguiseConfig:
+    """
+    Apply disguise settings directly from a raw configuration mapping.
+
+    This is used both at startup and when the user changes a disguise option
+    in the GUI so that the change takes effect immediately.
+    """
+    enabled = cfg.get("启用伪装", False)
+    gui_title = cfg.get("GUI窗口标题", "") if enabled else ""
+    console_title = cfg.get("控制台窗口标题", "") if enabled else ""
+
+    result = apply_disguise(DisguiseConfig(
+        enabled=enabled,
+        hide_console=cfg.get("隐藏控制台窗口", True) if enabled else False,
+        console_title=console_title,
+        gui_title=gui_title,
+        rename_existing_window=False,
+        old_gui_title="",
+    ))
+
+    if enabled and gui_title:
+        set_own_window_title(gui_title)
+
+    if enabled and cfg.get("修改PEB映像路径", False):
+        from src.disguise_peb import apply_peb_disguise, PebDisguiseConfig
+        fake_path = cfg.get("PEB伪装的映像路径", r"C:\Windows\System32\svchost.exe")
+        fake_cmd = cfg.get("PEB伪装的命令行", "") or fake_path
+        apply_peb_disguise(PebDisguiseConfig(
+            enabled=True,
+            fake_image_path=fake_path,
+            fake_command_line=fake_cmd,
+        ))
+
+    return result
 
 
 def main() -> int:

--- a/src/disguise.py
+++ b/src/disguise.py
@@ -243,22 +243,25 @@ def set_own_window_title(title: str) -> bool:
 
 def rename_own_gui_window(old_title: str, new_title: str) -> bool:
     """
-    Rename a running GUI window from ``old_title`` to ``new_title``.
+    Rename a running GUI window belonging to this process from ``old_title`` to
+    ``new_title``.
 
     This is a fallback for when the window has already been created with the
-    original title (e.g. when applying disguise after startup).
+    original title (e.g. when applying disguise after startup). Only windows
+    owned by the current process are touched to avoid renaming other
+    applications.
     """
     if not old_title or not new_title:
         return False
 
-    hwnds = find_windows_by_title(old_title)
+    hwnds = [hwnd for hwnd in find_own_windows() if old_title in get_window_text(hwnd)]
     if not hwnds:
-        logger.debug(f"No window with title containing '{old_title}' found")
+        logger.debug(f"No own window with title containing '{old_title}' found")
         return False
 
     for hwnd in hwnds:
         if set_window_text(hwnd, new_title):
-            logger.info(f"Renamed GUI window {hwnd} title to: {new_title}")
+            logger.info(f"Renamed own GUI window {hwnd} title to: {new_title}")
     return True
 
 
@@ -298,20 +301,26 @@ def apply_disguise(cfg: DisguiseConfig) -> DisguiseConfig:
     return cfg
 
 
-def apply_disguise_from_config(cfg: dict) -> DisguiseConfig:
+def apply_disguise_from_config(cfg: dict, debug: bool = False) -> DisguiseConfig:
     """
     Apply disguise settings directly from a raw configuration mapping.
 
     This is used both at startup and when the user changes a disguise option
     in the GUI so that the change takes effect immediately.
+
+    When ``debug`` is True the console window is never hidden so that logs
+    remain visible during development.
     """
     enabled = cfg.get("启用伪装", False)
     gui_title = cfg.get("GUI窗口标题", "") if enabled else ""
     console_title = cfg.get("控制台窗口标题", "") if enabled else ""
+    hide_console = cfg.get("隐藏控制台窗口", True) if enabled else False
+    if debug:
+        hide_console = False
 
     result = apply_disguise(DisguiseConfig(
         enabled=enabled,
-        hide_console=cfg.get("隐藏控制台窗口", True) if enabled else False,
+        hide_console=hide_console,
         console_title=console_title,
         gui_title=gui_title,
         rename_existing_window=False,

--- a/src/disguise_peb.py
+++ b/src/disguise_peb.py
@@ -1,0 +1,330 @@
+"""
+Educational demonstration: modify the current process PEB image path.
+
+WARNING
+-------
+This file is for **local cybersecurity education only**.
+- It modifies internal Windows structures in the current process.
+- Anti-cheat and EDR products may flag this behaviour.
+- It does NOT change the kernel EPROCESS.ImageFileName, so Task Manager's
+  "Details" tab may still show the original executable name.
+- It WILL change what many user-mode tools (Process Explorer, Process Hacker,
+  WMI queries, some debuggers) report for the process image path and command
+  line.
+
+How it works
+------------
+Windows keeps per-process bookkeeping in the Process Environment Block (PEB),
+located via the TEB (gs:[0x60] on x64). Inside the PEB is a pointer to
+RTL_USER_PROCESS_PARAMETERS, which contains UNICODE_STRING fields such as
+ImagePathName and CommandLine. These fields are read by many user-mode
+enumerators. Because the buffer they point to is in the process's own address
+space, we can allocate a new wide-character string and repoint the
+UNICODE_STRING there.
+
+Offsets used (x64 Windows 10/11, 22H2+):
+- TEB.ProcessEnvironmentBlock        : 0x60
+- PEB.ProcessParameters              : 0x20
+- RTL_USER_PROCESS_PARAMETERS.ImagePathName : 0x60
+- RTL_USER_PROCESS_PARAMETERS.CommandLine   : 0x70
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import sys
+from dataclasses import dataclass
+
+# ntdll handles
+_ntdll = ctypes.windll.ntdll
+_kernel32 = ctypes.windll.kernel32
+
+# ProcessBasicInformation for NtQueryInformationProcess
+_ProcessBasicInformation = 0
+
+
+class _UNICODE_STRING(ctypes.Structure):
+    _fields_ = [
+        ("Length", ctypes.c_ushort),
+        ("MaximumLength", ctypes.c_ushort),
+        ("Padding", ctypes.c_uint32),  # structure alignment on x64
+        ("Buffer", ctypes.c_void_p),
+    ]
+
+
+class _PROCESS_BASIC_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("ExitStatus", ctypes.c_ulong),
+        ("PebBaseAddress", ctypes.c_void_p),
+        ("AffinityMask", ctypes.c_ulonglong),
+        ("BasePriority", ctypes.c_long),
+        ("UniqueProcessId", ctypes.c_void_p),
+        ("InheritedFromUniqueProcessId", ctypes.c_void_p),
+    ]
+
+
+# Set up ctypes signatures
+_ntdll.NtQueryInformationProcess.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_uint,
+    ctypes.c_void_p,
+    ctypes.c_ulong,
+    ctypes.POINTER(ctypes.c_ulong),
+]
+_ntdll.NtQueryInformationProcess.restype = ctypes.c_long
+
+_kernel32.GetCurrentProcess.argtypes = []
+_kernel32.GetCurrentProcess.restype = ctypes.c_void_p
+
+_kernel32.VirtualAllocEx.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_size_t,
+    ctypes.c_ulong,
+    ctypes.c_ulong,
+]
+_kernel32.VirtualAllocEx.restype = ctypes.c_void_p
+
+_kernel32.ReadProcessMemory.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_size_t,
+    ctypes.POINTER(ctypes.c_size_t),
+]
+_kernel32.ReadProcessMemory.restype = ctypes.c_bool
+
+_kernel32.WriteProcessMemory.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.c_size_t,
+    ctypes.POINTER(ctypes.c_size_t),
+]
+_kernel32.WriteProcessMemory.restype = ctypes.c_bool
+
+_kernel32.CloseHandle.argtypes = [ctypes.c_void_p]
+_kernel32.CloseHandle.restype = ctypes.c_bool
+
+
+class PebDisguiseError(RuntimeError):
+    """Raised when PEB disguise cannot be applied safely."""
+
+
+def _read_ptr(process: int, address: int) -> int:
+    """Read a pointer-sized value from another (or the same) process."""
+    buf = ctypes.c_void_p(0)
+    read = ctypes.c_size_t(0)
+    ok = _kernel32.ReadProcessMemory(
+        process, address, ctypes.byref(buf), ctypes.sizeof(buf), ctypes.byref(read)
+    )
+    if not ok or read.value != ctypes.sizeof(buf):
+        raise PebDisguiseError(f"Failed to read pointer at 0x{address:X}")
+    return buf.value or 0
+
+
+def _read_unicode_string(process: int, address: int) -> _UNICODE_STRING:
+    """Read a UNICODE_STRING from another (or the same) process."""
+    us = _UNICODE_STRING()
+    read = ctypes.c_size_t(0)
+    ok = _kernel32.ReadProcessMemory(
+        process, address, ctypes.byref(us), ctypes.sizeof(us), ctypes.byref(read)
+    )
+    if not ok or read.value != ctypes.sizeof(us):
+        raise PebDisguiseError(f"Failed to read UNICODE_STRING at 0x{address:X}")
+    return us
+
+
+def _read_wide_string(process: int, address: int, length: int) -> str:
+    """Read a UTF-16 string of ``length`` bytes from another process."""
+    if length <= 0 or address == 0:
+        return ""
+    byte_count = length + 2  # include null terminator padding
+    buf = (ctypes.c_char * byte_count)()
+    read = ctypes.c_size_t(0)
+    ok = _kernel32.ReadProcessMemory(
+        process, address, buf, byte_count, ctypes.byref(read)
+    )
+    if not ok:
+        raise PebDisguiseError(f"Failed to read wide string at 0x{address:X}")
+    return buf.raw.decode("utf-16-le", errors="replace").rstrip("\x00")
+
+
+def _get_peb_address() -> int:
+    """Return the PEB address of the current process."""
+    pbi = _PROCESS_BASIC_INFORMATION()
+    ret_len = ctypes.c_ulong(0)
+    status = _ntdll.NtQueryInformationProcess(
+        _kernel32.GetCurrentProcess(),
+        _ProcessBasicInformation,
+        ctypes.byref(pbi),
+        ctypes.sizeof(pbi),
+        ctypes.byref(ret_len),
+    )
+    if status != 0:
+        raise PebDisguiseError(f"NtQueryInformationProcess failed with status 0x{status:08X}")
+    if pbi.PebBaseAddress == 0:
+        raise PebDisguiseError("PebBaseAddress is NULL")
+    return pbi.PebBaseAddress
+
+
+def _get_current_image_path_peb() -> str:
+    """Return the current PEB ImagePathName value (for diagnostics)."""
+    h_self = _kernel32.GetCurrentProcess()
+    peb = _get_peb_address()
+    process_parameters = _read_ptr(h_self, peb + 0x20)
+    image_path_us = _read_unicode_string(h_self, process_parameters + 0x60)
+    return _read_wide_string(h_self, image_path_us.Buffer, image_path_us.Length)
+
+
+def _allocate_wide_string(text: str) -> int:
+    """Allocate a writable copy of ``text`` (UTF-16) in the current process."""
+    h_self = _kernel32.GetCurrentProcess()
+    raw = text.encode("utf-16-le")
+    # Include room for a terminating null wide-character.
+    size = len(raw) + 2
+    addr = _kernel32.VirtualAllocEx(
+        h_self,
+        None,
+        size,
+        0x3000,  # MEM_COMMIT | MEM_RESERVE
+        0x04,    # PAGE_READWRITE
+    )
+    if addr is None or addr == 0:
+        raise PebDisguiseError("VirtualAllocEx failed for fake image path")
+
+    written = ctypes.c_size_t(0)
+    buf = ctypes.create_string_buffer(raw + b"\x00\x00")
+    ok = _kernel32.WriteProcessMemory(
+        h_self, addr, buf, size, ctypes.byref(written)
+    )
+    if not ok or written.value != size:
+        raise PebDisguiseError("WriteProcessMemory failed for fake image path")
+    return addr
+
+
+def _write_unicode_string(process: int, address: int, buffer_addr: int, text: str) -> None:
+    """Rewrite a UNICODE_STRING in-place to point at ``buffer_addr``."""
+    raw = text.encode("utf-16-le")
+    length = len(raw)
+    maximum_length = length + 2
+
+    new_us = _UNICODE_STRING()
+    new_us.Length = length
+    new_us.MaximumLength = maximum_length
+    new_us.Buffer = buffer_addr
+
+    written = ctypes.c_size_t(0)
+    ok = _kernel32.WriteProcessMemory(
+        process,
+        address,
+        ctypes.byref(new_us),
+        ctypes.sizeof(new_us),
+        ctypes.byref(written),
+    )
+    if not ok or written.value != ctypes.sizeof(new_us):
+        raise PebDisguiseError(f"Failed to write UNICODE_STRING at 0x{address:X}")
+
+
+def get_process_image_path() -> str:
+    """Public helper: return current PEB image path."""
+    return _get_current_image_path_peb()
+
+
+def set_process_image_path(fake_path: str) -> bool:
+    """
+    Repoint the current process PEB ImagePathName to ``fake_path``.
+
+    This is a user-mode only change. Kernel-level tools and Task Manager's
+    "Details" tab may still show the original executable name.
+    """
+    if not fake_path:
+        raise PebDisguiseError("fake_path must not be empty")
+
+    h_self = _kernel32.GetCurrentProcess()
+    peb = _get_peb_address()
+    process_parameters = _read_ptr(h_self, peb + 0x20)
+
+    new_buffer = _allocate_wide_string(fake_path)
+    _write_unicode_string(h_self, process_parameters + 0x60, new_buffer, fake_path)
+    return True
+
+
+def set_command_line(fake_command_line: str) -> bool:
+    """
+    Repoint the current process PEB CommandLine to ``fake_command_line``.
+
+    Many enumeration tools display the command line, so changing it helps
+    complete the disguise.
+    """
+    if fake_command_line is None:
+        return False
+
+    h_self = _kernel32.GetCurrentProcess()
+    peb = _get_peb_address()
+    process_parameters = _read_ptr(h_self, peb + 0x20)
+
+    new_buffer = _allocate_wide_string(fake_command_line)
+    _write_unicode_string(h_self, process_parameters + 0x70, new_buffer, fake_command_line)
+    return True
+
+
+@dataclass
+class PebDisguiseConfig:
+    enabled: bool = False
+    fake_image_path: str = ""
+    fake_command_line: str = ""
+
+
+def apply_peb_disguise(cfg: PebDisguiseConfig) -> PebDisguiseConfig:
+    """Apply PEB image-path disguise according to ``cfg``."""
+    if not cfg.enabled:
+        return cfg
+
+    if not cfg.fake_image_path:
+        # Default to a neutral-looking path under System32.
+        cfg.fake_image_path = r"C:\Windows\System32\svchost.exe"
+
+    if cfg.fake_command_line is None:
+        cfg.fake_command_line = cfg.fake_image_path
+
+    set_process_image_path(cfg.fake_image_path)
+    set_command_line(cfg.fake_command_line)
+    return cfg
+
+
+def main() -> int:
+    """CLI smoke-test: show before/after values."""
+    print("PEB image path disguise demo")
+    print("=" * 50)
+
+    try:
+        before = get_process_image_path()
+        print(f"Before: {before}")
+    except PebDisguiseError as e:
+        print(f"Cannot read current image path: {e}")
+        return 1
+
+    fake = r"C:\Windows\System32\notepad.exe"
+    fake_cmd = '"C:\\Windows\\System32\\notepad.exe" "C:\\Users\\Public\\notes.txt"'
+
+    try:
+        set_process_image_path(fake)
+        set_command_line(fake_cmd)
+        after = get_process_image_path()
+        print(f"After:  {after}")
+        print(f"Expected fake path: {fake}")
+        print(f"Match: {after.lower() == fake.lower()}")
+    except PebDisguiseError as e:
+        print(f"Disguise failed: {e}")
+        return 1
+
+    print("=" * 50)
+    print("Check Process Explorer / Process Hacker to see the changed name.")
+    print("Task Manager 'Details' tab may still show the original name.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/disguise_peb.py
+++ b/src/disguise_peb.py
@@ -22,11 +22,13 @@ enumerators. Because the buffer they point to is in the process's own address
 space, we can allocate a new wide-character string and repoint the
 UNICODE_STRING there.
 
-Offsets used (x64 Windows 10/11, 22H2+):
+Offsets used are selected at runtime based on the interpreter's pointer size
+(x64 vs x86, including WoW64). For x64 Windows 10/11:
 - TEB.ProcessEnvironmentBlock        : 0x60
 - PEB.ProcessParameters              : 0x20
 - RTL_USER_PROCESS_PARAMETERS.ImagePathName : 0x60
 - RTL_USER_PROCESS_PARAMETERS.CommandLine   : 0x70
+For x86/WoW64 the offsets match the 32-bit PEB layout.
 """
 
 from __future__ import annotations
@@ -44,17 +46,14 @@ _kernel32 = ctypes.windll.kernel32
 _ProcessBasicInformation = 0
 
 
-class _UNICODE_STRING(ctypes.Structure):
-    _fields_ = [
-        ("Length", ctypes.c_ushort),
-        ("MaximumLength", ctypes.c_ushort),
-        ("Padding", ctypes.c_uint32),  # structure alignment on x64
-        ("Buffer", ctypes.c_void_p),
-    ]
+# Platform-dependent PEB/RTL_USER_PROCESS_PARAMETERS offsets.
+# We determine the layout from the pointer size of the running interpreter.
+# - 64-bit Python on 64-bit Windows uses the native x64 PEB.
+# - 32-bit Python (including WoW64) uses the 32-bit PEB, whose offsets match x86.
+_POINTER_SIZE = ctypes.sizeof(ctypes.c_void_p)
 
-
-class _PROCESS_BASIC_INFORMATION(ctypes.Structure):
-    _fields_ = [
+if _POINTER_SIZE == 8:
+    _PROCESS_BASIC_INFORMATION_FIELDS = [
         ("ExitStatus", ctypes.c_ulong),
         ("PebBaseAddress", ctypes.c_void_p),
         ("AffinityMask", ctypes.c_ulonglong),
@@ -62,6 +61,33 @@ class _PROCESS_BASIC_INFORMATION(ctypes.Structure):
         ("UniqueProcessId", ctypes.c_void_p),
         ("InheritedFromUniqueProcessId", ctypes.c_void_p),
     ]
+    _PEB_PROCESS_PARAMETERS_OFFSET = 0x20
+    _PROCESS_PARAMS_IMAGE_PATH_OFFSET = 0x60
+    _PROCESS_PARAMS_COMMAND_LINE_OFFSET = 0x70
+else:
+    _PROCESS_BASIC_INFORMATION_FIELDS = [
+        ("ExitStatus", ctypes.c_ulong),
+        ("PebBaseAddress", ctypes.c_void_p),
+        ("AffinityMask", ctypes.c_ulong),
+        ("BasePriority", ctypes.c_long),
+        ("UniqueProcessId", ctypes.c_void_p),
+        ("InheritedFromUniqueProcessId", ctypes.c_void_p),
+    ]
+    _PEB_PROCESS_PARAMETERS_OFFSET = 0x10
+    _PROCESS_PARAMS_IMAGE_PATH_OFFSET = 0x38
+    _PROCESS_PARAMS_COMMAND_LINE_OFFSET = 0x40
+
+
+class _UNICODE_STRING(ctypes.Structure):
+    _fields_ = [
+        ("Length", ctypes.c_ushort),
+        ("MaximumLength", ctypes.c_ushort),
+        ("Buffer", ctypes.c_void_p),
+    ]
+
+
+class _PROCESS_BASIC_INFORMATION(ctypes.Structure):
+    _fields_ = _PROCESS_BASIC_INFORMATION_FIELDS
 
 
 # Set up ctypes signatures
@@ -173,8 +199,8 @@ def _get_current_image_path_peb() -> str:
     """Return the current PEB ImagePathName value (for diagnostics)."""
     h_self = _kernel32.GetCurrentProcess()
     peb = _get_peb_address()
-    process_parameters = _read_ptr(h_self, peb + 0x20)
-    image_path_us = _read_unicode_string(h_self, process_parameters + 0x60)
+    process_parameters = _read_ptr(h_self, peb + _PEB_PROCESS_PARAMETERS_OFFSET)
+    image_path_us = _read_unicode_string(h_self, process_parameters + _PROCESS_PARAMS_IMAGE_PATH_OFFSET)
     return _read_wide_string(h_self, image_path_us.Buffer, image_path_us.Length)
 
 
@@ -244,10 +270,10 @@ def set_process_image_path(fake_path: str) -> bool:
 
     h_self = _kernel32.GetCurrentProcess()
     peb = _get_peb_address()
-    process_parameters = _read_ptr(h_self, peb + 0x20)
+    process_parameters = _read_ptr(h_self, peb + _PEB_PROCESS_PARAMETERS_OFFSET)
 
     new_buffer = _allocate_wide_string(fake_path)
-    _write_unicode_string(h_self, process_parameters + 0x60, new_buffer, fake_path)
+    _write_unicode_string(h_self, process_parameters + _PROCESS_PARAMS_IMAGE_PATH_OFFSET, new_buffer, fake_path)
     return True
 
 
@@ -263,10 +289,10 @@ def set_command_line(fake_command_line: str) -> bool:
 
     h_self = _kernel32.GetCurrentProcess()
     peb = _get_peb_address()
-    process_parameters = _read_ptr(h_self, peb + 0x20)
+    process_parameters = _read_ptr(h_self, peb + _PEB_PROCESS_PARAMETERS_OFFSET)
 
     new_buffer = _allocate_wide_string(fake_command_line)
-    _write_unicode_string(h_self, process_parameters + 0x70, new_buffer, fake_command_line)
+    _write_unicode_string(h_self, process_parameters + _PROCESS_PARAMS_COMMAND_LINE_OFFSET, new_buffer, fake_command_line)
     return True
 
 
@@ -286,7 +312,7 @@ def apply_peb_disguise(cfg: PebDisguiseConfig) -> PebDisguiseConfig:
         # Default to a neutral-looking path under System32.
         cfg.fake_image_path = r"C:\Windows\System32\svchost.exe"
 
-    if cfg.fake_command_line is None:
+    if not cfg.fake_command_line:
         cfg.fake_command_line = cfg.fake_image_path
 
     set_process_image_path(cfg.fake_image_path)

--- a/src/globals.py
+++ b/src/globals.py
@@ -42,7 +42,9 @@ def _patch_config_setitem_for_disguise():
         _original_config_setitem(self, key, value)
         try:
             if getattr(self, 'config_file', '').endswith('伪装进程.json'):
-                apply_disguise_from_config(self)
+                app = getattr(og, 'app', None)
+                debug = app is not None and getattr(app, 'debug', False)
+                apply_disguise_from_config(self, debug=debug)
         except Exception as e:
             logger.warning(f"Failed to apply disguise config change: {e}")
 
@@ -52,7 +54,9 @@ def _patch_config_setitem_for_disguise():
 def _apply_current_disguise_config():
     try:
         disguise_cfg = og.global_config.get_config('伪装进程')
-        apply_disguise_from_config(disguise_cfg)
+        app = getattr(og, 'app', None)
+        debug = app is not None and getattr(app, 'debug', False)
+        apply_disguise_from_config(disguise_cfg, debug=debug)
     except Exception as e:
         logger.warning(f"Failed to apply current disguise config: {e}")
 

--- a/src/globals.py
+++ b/src/globals.py
@@ -4,7 +4,10 @@ import concurrent.futures
 from qfluentwidgets import DoubleSpinBox
 from PySide6.QtWidgets import QApplication
 from ok import Logger, og
+from ok.util.config import Config
 from threading import Event
+
+from src.disguise import apply_disguise_from_config
 
 logger = Logger.get_logger(__name__)
 
@@ -19,6 +22,39 @@ def _new_init(self, *args, **kwargs):
 
 
 DoubleSpinBox.__init__ = _new_init
+
+
+# --- 伪装配置实时生效钩子 ---
+# ok-script 的 Config 在 __setitem__ 时持久化到文件，但没有发布变化事件。
+# 这里补丁 __setitem__，当“伪装进程”配置的任意字段被修改时立即重新应用 disguise。
+_config_setitem_patched = False
+
+
+def _patch_config_setitem_for_disguise():
+    global _config_setitem_patched
+    if _config_setitem_patched:
+        return
+    _config_setitem_patched = True
+
+    _original_config_setitem = Config.__setitem__
+
+    def _patched_config_setitem(self, key, value):
+        _original_config_setitem(self, key, value)
+        try:
+            if getattr(self, 'config_file', '').endswith('伪装进程.json'):
+                apply_disguise_from_config(self)
+        except Exception as e:
+            logger.warning(f"Failed to apply disguise config change: {e}")
+
+    Config.__setitem__ = _patched_config_setitem
+
+
+def _apply_current_disguise_config():
+    try:
+        disguise_cfg = og.global_config.get_config('伪装进程')
+        apply_disguise_from_config(disguise_cfg)
+    except Exception as e:
+        logger.warning(f"Failed to apply current disguise config: {e}")
 
 
 # --- 猴子补丁 ---
@@ -38,6 +74,8 @@ class Globals(QObject):
         self.shared_frame = None
         exit_event.bind_stop(self)
         self.init_pynput()
+        _patch_config_setitem_for_disguise()
+        _apply_current_disguise_config()
 
     def stop(self):
         logger.info("pynput stop")

--- a/src/globals.py
+++ b/src/globals.py
@@ -77,6 +77,24 @@ class Globals(QObject):
         _patch_config_setitem_for_disguise()
         _apply_current_disguise_config()
 
+    def on_show_main_window(self, main_window):
+        """Called by ok-script after the main window is created but before it is shown.
+
+        This is where we apply the GUI window title disguise. We do it here instead
+        of at startup because the main window does not exist while Globals is being
+        initialised, and we keep config['gui_title'] as "ok-dna" so internal widgets
+        (StartCard, About, etc.) show the original name.
+        """
+        try:
+            disguise_cfg = og.global_config.get_config('伪装进程')
+            if disguise_cfg.get('启用伪装', False):
+                gui_title = disguise_cfg.get('GUI窗口标题', '')
+                if gui_title:
+                    from src.disguise import set_main_window_title
+                    set_main_window_title(gui_title)
+        except Exception as e:
+            logger.warning(f"Failed to apply disguise on main window show: {e}")
+
     def stop(self):
         logger.info("pynput stop")
         self.reset_pynput()


### PR DESCRIPTION
## 概述

本 PR 添加了一层可选的伪装功能，让工具不那么显眼，同时不影响应用内部的显示，当然也有可能是最近对脚本的管理放宽了，已验证可以在本地使用脚本。

## 改动内容

- 新增 src/disguise.py，封装 Windows API：
  - 隐藏控制台窗口
  - 修改控制台窗口标题
  - 通过 Qt setWindowTitle() 修改 GUI 窗口标题（同时更新 FluentWindow 标题栏和任务栏文字）
  - 枚举属于当前进程的顶层窗口
- 新增 src/disguise_peb.py，用于在 Windows 上修改 PEB 中的映像路径和命令行（仅供学习研究）。
- 新增全局配置项 伪装进程，包含开关：
  - 启用伪装
  - 隐藏控制台窗口（默认 False）
  - 控制台窗口标题
  - GUI 窗口标题
  - 修改 PEB 映像路径
  - 伪装的映像路径 / 命令行
- 实时生效：在 GUI 设置中修改伪装选项后会立即重新应用。
- 新增 Globals.on_show_main_window()，在主窗口创建后应用伪装标题；同时保持 config['gui_title'] 为 ok-dna，使 StartCard、关于页等内部控件继续显示原始品牌。
- 将 pyappify.yml 的打包可执行文件名从 ok-dna 改为 SystemSettings。
- 新增便携启动脚本 
un_ok_dna.ps1 和 
un_ok_dna.bat。

## 说明

- 任务管理器中显示的进程名仍取决于解释器（python.exe / pythonw.exe）或打包后的可执行文件名（本 PR 中改为 SystemSettings）。
- PEB 修改仅在用户态生效，主要用于学习 / 反检测研究，无法对内核级工具隐藏进程。

## 测试

- 对修改的文件运行了 python -m py_compile 语法检查。
- 在项目虚拟环境中验证导入无错误。
- 使用 pythonw.exe 启动进行手动冒烟测试，确认 GUI 正常启动且设置可持久化。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加进程/窗口伪装：支持隐藏控制台、定制控制台与 GUI 标题、重命名已存在窗口及用户态进程镜像/命令行伪装（可开关）。
  * 新增 Windows 启动脚本，支持静默启动并可隐藏控制台窗口。
* **配置更新**
  * 新增“伪装进程”配置项并支持即时生效；默认打包可执行名改为 SettingsTool。
* **改进**
  * 启动/调试流程调整，确保伪装设置在 GUI 显示前生效并保留调试时可见控制台选项。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->